### PR TITLE
Fixed JS bug where Backdrop.attachBehaviors was being called twice

### DIFF
--- a/eu_cookie_compliance.module
+++ b/eu_cookie_compliance.module
@@ -321,7 +321,6 @@ function eu_cookie_compliance_preprocess_page(&$variables) {
       }
     }
 
-    //backdrop_add_js('function euCookieComplianceLoadScripts() {' . $load_disabled_scripts . 'Backdrop.attachBehaviors();}', array('type' => 'inline', 'scope' => $script_scope));
     backdrop_add_js('function euCookieComplianceLoadScripts() {' . $load_disabled_scripts . '}', array('type' => 'inline', 'scope' => $script_scope));
 
     // Add the cookie name inline, since Backdrop.settings will not be available

--- a/eu_cookie_compliance.module
+++ b/eu_cookie_compliance.module
@@ -321,7 +321,8 @@ function eu_cookie_compliance_preprocess_page(&$variables) {
       }
     }
 
-    backdrop_add_js('function euCookieComplianceLoadScripts() {' . $load_disabled_scripts . 'Backdrop.attachBehaviors();}', array('type' => 'inline', 'scope' => $script_scope));
+    //backdrop_add_js('function euCookieComplianceLoadScripts() {' . $load_disabled_scripts . 'Backdrop.attachBehaviors();}', array('type' => 'inline', 'scope' => $script_scope));
+    backdrop_add_js('function euCookieComplianceLoadScripts() {' . $load_disabled_scripts . '}', array('type' => 'inline', 'scope' => $script_scope));
 
     // Add the cookie name inline, since Backdrop.settings will not be available
     // if the script is loaded in the header.


### PR DESCRIPTION
Fixes #14. This was causing "more" and "less" links in Backdrop to try to get executed twice.